### PR TITLE
Add Cursor Cloud development environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,37 +233,13 @@ Based on https://12factor.net/ and https://github.com/humanlayer/12-factor-agent
 
 ---
 
-## Cursor Cloud specific instructions
-
-### Environment
-
-- Python 3.12 venv at `.venv/`. Always `source .venv/bin/activate` before running any Python commands.
-- Dependencies come from `requirements.txt` (pinned versions). The update script handles `pip install -r requirements.txt`.
-- `.env` is copied from `.env.example` on first setup. LLM API keys default to placeholder `XXX` values.
-
-### Running the app
-
-- `python agent_ng/app_ng_modular.py` starts Gradio on `0.0.0.0:7860`.
-- The app starts even without valid API keys; chat requests return 401 errors but the UI is fully functional.
-- On startup, the app fetches OpenRouter model pricing via HTTP (takes ~10-15 s); this is normal and not an error.
-
-### Linting
-
-- `ruff check agent_ng/ tools/` for lint. The codebase has ~3 k pre-existing findings; many are intentionally unfixable per `pyproject.toml`. Focus on new findings in files you change.
-- `python lint.py` lints only changed files (vs HEAD) by default.
-
-### Testing
-
-- `python -m pytest agent_ng/_tests/` runs unit tests. Three test files have pre-existing import errors (`test_concurrency.py`, `test_debug_system.py`, `test_streaming_agent_behavior.py`) and must be skipped or will cause collection errors.
-- Integration tests require `CMW_INTEGRATION_TESTS=1` plus a live CMW Platform server and are skipped by default.
-- 222 tests pass, ~21 fail pre-existing; do not treat pre-existing failures as regressions.
-
-### External services
-
-- **LLM providers**: At least one API key (`OPENROUTER_API_KEY`, `GEMINI_KEY`, `GROQ_API_KEY`, etc.) is needed for actual chat functionality. Without keys the app starts but chat returns auth errors.
-- **CMW Platform**: Optional; 38 platform tools need `CMW_BASE_URL`/`CMW_LOGIN`/`CMW_PASSWORD`. The 23 utility tools work without it.
-- No Docker, no databases, no message queues are required.
-
----
-
 **Remember:** LangChain-pure, DRY, lean, modular, pythonic patterns. Always research first, plan thoroughly, produce flawless code.
+
+## Agent Environment Notes
+
+Non-obvious caveats for automated agents. For standard setup, run, lint, and test commands see the **Development Setup** section in `README.md`.
+
+- On startup, the app fetches OpenRouter model pricing via HTTP (~10-15 s of network calls). This is normal, not an error.
+- The codebase has ~3 k pre-existing `ruff` findings; many are intentionally unfixable per `pyproject.toml`. Only focus on new findings in files you change.
+- Three test files have pre-existing import errors and will cause collection failures if not skipped: `test_concurrency.py`, `test_debug_system.py`, `test_streaming_agent_behavior.py`.
+- ~21 tests fail pre-existing on `main`; do not treat these as regressions introduced by your changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,4 +233,37 @@ Based on https://12factor.net/ and https://github.com/humanlayer/12-factor-agent
 
 ---
 
+## Cursor Cloud specific instructions
+
+### Environment
+
+- Python 3.12 venv at `.venv/`. Always `source .venv/bin/activate` before running any Python commands.
+- Dependencies come from `requirements.txt` (pinned versions). The update script handles `pip install -r requirements.txt`.
+- `.env` is copied from `.env.example` on first setup. LLM API keys default to placeholder `XXX` values.
+
+### Running the app
+
+- `python agent_ng/app_ng_modular.py` starts Gradio on `0.0.0.0:7860`.
+- The app starts even without valid API keys; chat requests return 401 errors but the UI is fully functional.
+- On startup, the app fetches OpenRouter model pricing via HTTP (takes ~10-15 s); this is normal and not an error.
+
+### Linting
+
+- `ruff check agent_ng/ tools/` for lint. The codebase has ~3 k pre-existing findings; many are intentionally unfixable per `pyproject.toml`. Focus on new findings in files you change.
+- `python lint.py` lints only changed files (vs HEAD) by default.
+
+### Testing
+
+- `python -m pytest agent_ng/_tests/` runs unit tests. Three test files have pre-existing import errors (`test_concurrency.py`, `test_debug_system.py`, `test_streaming_agent_behavior.py`) and must be skipped or will cause collection errors.
+- Integration tests require `CMW_INTEGRATION_TESTS=1` plus a live CMW Platform server and are skipped by default.
+- 222 tests pass, ~21 fail pre-existing; do not treat pre-existing failures as regressions.
+
+### External services
+
+- **LLM providers**: At least one API key (`OPENROUTER_API_KEY`, `GEMINI_KEY`, `GROQ_API_KEY`, etc.) is needed for actual chat functionality. Without keys the app starts but chat returns auth errors.
+- **CMW Platform**: Optional; 38 platform tools need `CMW_BASE_URL`/`CMW_LOGIN`/`CMW_PASSWORD`. The 23 utility tools work without it.
+- No Docker, no databases, no message queues are required.
+
+---
+
 **Remember:** LangChain-pure, DRY, lean, modular, pythonic patterns. Always research first, plan thoroughly, produce flawless code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,4 +241,4 @@ Non-obvious caveats. For standard setup, run, lint, and test commands see the **
 
 - On startup, the app fetches OpenRouter model pricing via HTTP (~10-15 s of network calls). This is normal, not an error.
 - Some `ruff` findings are intentionally unfixable per `pyproject.toml`. When in doubt about whether to fix a lint finding, ask the user.
-- On a clean first start with dummy/empty `.env`, some tests may fail or error due to missing credentials or import issues. This is expected; configure real API keys and check test prerequisites before investigating failures.
+- On a clean first start with dummy/empty `.env`, some tests may fail or error due to missing credentials or import issues. Configure real API keys and check test prerequisites first; if failures persist, ask the user before investigating further.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,9 +237,8 @@ Based on https://12factor.net/ and https://github.com/humanlayer/12-factor-agent
 
 ## Agent Environment Notes
 
-Non-obvious caveats for automated agents. For standard setup, run, lint, and test commands see the **Development Setup** section in `README.md`.
+Non-obvious caveats. For standard setup, run, lint, and test commands see the **Development Setup** section in `README.md`.
 
 - On startup, the app fetches OpenRouter model pricing via HTTP (~10-15 s of network calls). This is normal, not an error.
 - The codebase has ~3 k pre-existing `ruff` findings; many are intentionally unfixable per `pyproject.toml`. Only focus on new findings in files you change.
-- Three test files have pre-existing import errors and will cause collection failures if not skipped: `test_concurrency.py`, `test_debug_system.py`, `test_streaming_agent_behavior.py`.
-- ~21 tests fail pre-existing on `main`; do not treat these as regressions introduced by your changes.
+- On a clean first start with dummy/empty `.env`, some tests may fail or error due to missing credentials or import issues. This is expected; configure real API keys and check test prerequisites before investigating failures.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,5 +240,5 @@ Based on https://12factor.net/ and https://github.com/humanlayer/12-factor-agent
 Non-obvious caveats. For standard setup, run, lint, and test commands see the **Development Setup** section in `README.md`.
 
 - On startup, the app fetches OpenRouter model pricing via HTTP (~10-15 s of network calls). This is normal, not an error.
-- The codebase has ~3 k pre-existing `ruff` findings; many are intentionally unfixable per `pyproject.toml`. Only focus on new findings in files you change.
+- Some `ruff` findings are intentionally unfixable per `pyproject.toml`. When in doubt about whether to fix a lint finding, ask the user.
 - On a clean first start with dummy/empty `.env`, some tests may fail or error due to missing credentials or import issues. This is expected; configure real API keys and check test prerequisites before investigating failures.

--- a/README.md
+++ b/README.md
@@ -366,21 +366,53 @@ This is an experimental research project. Contributions are welcome in the form 
 
 ### Development Setup
 
-1. **Activate virtual environment**:
+1. **Create and activate virtual environment**:
    ```bash
-   # Windows
-   .venv\Scripts\Activate.ps1
-   
-   # Linux/Mac
-   source .venv/bin/activate
+   python3 -m venv .venv
+   source .venv/bin/activate        # Linux/Mac/WSL
+   # .venv\Scripts\Activate.ps1     # PowerShell
    ```
 
-2. **Run tests**:
+2. **Install dependencies**:
    ```bash
-   python -m pytest agent_ng/_tests/
+   pip install -r requirements.txt
    ```
 
-3. **Code style**:
+3. **Configure environment**:
    ```bash
-   ruff check agent_ng/ tools/
+   cp .env.example .env
+   # Edit .env and set at least one LLM provider API key
    ```
+
+4. **Run the application**:
+   ```bash
+   python agent_ng/app_ng_modular.py
+   # Gradio UI starts on http://0.0.0.0:7860
+   ```
+   The app starts even without valid API keys (the UI is fully functional; chat requests return auth errors until a valid key is configured).
+
+5. **Run linter**:
+   ```bash
+   ruff check agent_ng/ tools/      # Lint core directories
+   python lint.py                    # Lint only changed files vs HEAD
+   python lint.py --all              # Lint entire repo
+   ```
+
+6. **Run tests**:
+   ```bash
+   python -m pytest agent_ng/_tests/           # All tests
+   python -m pytest agent_ng/_tests/test_x.py  # Single file
+   python -m pytest -k "pattern"               # Filter by name
+   ```
+   Integration tests require `CMW_INTEGRATION_TESTS=1` plus a live CMW Platform server and are skipped by default.
+
+7. **Typecheck**:
+   ```bash
+   mypy agent_ng/
+   ```
+
+### External Services
+
+- **LLM providers**: At least one API key is needed for chat functionality (`OPENROUTER_API_KEY`, `GEMINI_KEY`, `GROQ_API_KEY`, `MISTRAL_API_KEY`, `GIGACHAT_API_KEY`, or `HUGGINGFACE_API_KEY`). See `.env.example` for all options.
+- **CMW Platform** (optional): 38 platform tools require `CMW_BASE_URL`, `CMW_LOGIN`, `CMW_PASSWORD`. The 23 utility tools work without it.
+- **No Docker, databases, or message queues** are required. The app is a single Python process.

--- a/README.md
+++ b/README.md
@@ -367,10 +367,17 @@ This is an experimental research project. Contributions are welcome in the form 
 ### Development Setup
 
 1. **Create and activate virtual environment**:
+
+   Linux / Mac / WSL:
    ```bash
    python3 -m venv .venv
-   source .venv/bin/activate        # Linux/Mac/WSL
-   # .venv\Scripts\Activate.ps1     # PowerShell
+   source .venv/bin/activate
+   ```
+
+   Windows (PowerShell):
+   ```powershell
+   python -m venv .venv
+   .venv\Scripts\Activate.ps1
    ```
 
 2. **Install dependencies**:
@@ -387,7 +394,7 @@ This is an experimental research project. Contributions are welcome in the form 
 4. **Run the application**:
    ```bash
    python agent_ng/app_ng_modular.py
-   # Gradio UI starts on http://0.0.0.0:7860
+   # Gradio UI starts on the port configured by GRADIO_DEFAULT_PORT in .env (default 7860)
    ```
    The app starts even without valid API keys (the UI is fully functional; chat requests return auth errors until a valid key is configured).
 

--- a/README.md
+++ b/README.md
@@ -368,10 +368,16 @@ This is an experimental research project. Contributions are welcome in the form 
 
 1. **Create and activate virtual environment**:
 
-   Linux / Mac / WSL:
+   Linux / Mac:
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
+   ```
+
+   WSL (separate venv so Windows and WSL can run in parallel):
+   ```bash
+   python3 -m venv .venv-wsl
+   source .venv-wsl/bin/activate
    ```
 
    Windows (PowerShell):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds development environment documentation for both humans and agents.

### Changes

- **`README.md`**: Expanded the **Development Setup** section with complete step-by-step instructions (venv creation, dependency install, env config, run, lint, test, typecheck) and a new **External Services** section documenting LLM provider keys, CMW Platform, and the no-Docker/no-DB requirement.

- **`AGENTS.md`**: Added **Agent Environment Notes** section at the very end with non-obvious caveats only (OpenRouter pricing delay, pre-existing lint/test findings, broken test files to skip). References `README.md` for standard commands.

### Review feedback addressed

1. Section is agent-generic, not Cursor-specific
2. Section is at the very end of `AGENTS.md`
3. General dev setup info moved to `README.md` for both humans and agents

### Verification

[hello_world_provider_switch_and_chat.mp4](https://cursor.com/agents/bc-9fbffc96-84ba-424d-bf53-6d7a58294f84/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_provider_switch_and_chat.mp4)

Hello world walkthrough: switching LLM provider to Gemini, navigating all tabs, and sending a chat message.

[Provider switched to Gemini](https://cursor.com/agents/bc-9fbffc96-84ba-424d-bf53-6d7a58294f84/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprovider_switch_gemini.webp)
[Hello world chat message with expected auth error](https://cursor.com/agents/bc-9fbffc96-84ba-424d-bf53-6d7a58294f84/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_chat.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fbffc96-84ba-424d-bf53-6d7a58294f84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fbffc96-84ba-424d-bf53-6d7a58294f84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

