### PR TITLE
docs: sync README with current repo (tools, Python, venv)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - CMW Platform Agent
 
-Repo-specific guidance for this LangChain + Gradio Python 3.11+ project.
+Repo-specific guidance for this LangChain + Gradio Python 3.12+ project.
 
 ## Research & Planning
 
@@ -76,7 +76,7 @@ python -m pytest -k "pattern"              # Filter by name
 
 ## Code Style & Conventions
 
-- **Ruff (pyproject.toml):** Line length 88, Python 3.11+, double quotes. Many rules are `unfixable` - ruff flags but will not auto-fix (F401, F403, T201, PLR, ANN, etc). Run `ruff check --fix --unsafe-fixes` to auto-fix.
+- **Ruff (pyproject.toml):** Line length 88, Python 3.12+, double quotes. Many rules are `unfixable` - ruff flags but will not auto-fix (F401, F403, T201, PLR, ANN, etc). Run `ruff check --fix --unsafe-fixes` to auto-fix.
 - **Imports:** Standard library -> third-party -> local with fallback pattern:
 ```python
 try:

--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ The agent provides comprehensive integration with the CMW Platform through speci
 
 ### Tool Categories
 
-**CMW Platform Tools (47 tools)**
+**CMW Platform Tools**
 
 - **Applications & Templates**: List/create applications, manage templates, ontology/schema helpers, entity URLs, import/export
 - **Attributes**: All supported attribute types (Text, Boolean, DateTime, Decimal, Document, Drawing, Duration, Image, Record, Role, Account, Enum) plus get, create, edit, delete, archive
 - **Templates, forms, toolbars, buttons, records**: Template and record CRUD, datasets, forms, toolbars, buttons, record files
 
-**Utility Tools (24 tools)**
+**Utility Tools**
 
 - **Search & Research**: Web search, Wikipedia, ArXiv, deep research
 - **Code Execution**: Multi-language support (Python, Bash, SQL, C, Java)
@@ -427,5 +427,5 @@ This is an experimental research project. Contributions are welcome in the form 
 ### External Services
 
 - **LLM providers**: At least one API key is needed for chat functionality (`OPENROUTER_API_KEY`, `GEMINI_KEY`, `GROQ_API_KEY`, `MISTRAL_API_KEY`, `GIGACHAT_API_KEY`, or `HUGGINGFACE_API_KEY`). See `.env.example` for all options.
-- **CMW Platform** (optional): 47 platform tools require `CMW_BASE_URL`, `CMW_LOGIN`, `CMW_PASSWORD`. The 24 utility tools work without it.
+- **CMW Platform** (optional): Platform integration tools require `CMW_BASE_URL`, `CMW_LOGIN`, `CMW_PASSWORD`. Utility tools work without it.
 - **No Docker, databases, or message queues** are required. The app is a single Python process.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The Comindware Analyst Copilot is a LangChain-native AI agent designed for creat
 - **Real-Time Streaming**: Live response streaming with tool usage visualization
 - **Session Isolation**: Each user gets isolated agent instances with proper cleanup
 - **Internationalization**: Full support for English and Russian UI
-- **Comprehensive Tool Suite**: 71 specialized tools (47 CMW Platform + 24 general utility)
+- **Comprehensive Tool Suite**: 71 specialized tools
 
 ### Target Use Cases
 
@@ -89,7 +89,7 @@ graph TD
 
 - **CmwAgent** (`langchain_agent.py`) - Main orchestrator using pure LangChain patterns
 - **LLMManager** (`llm_manager.py`) - Multi-provider management with persistent instances
-- **Tool System** (`tools/`) - 71 LangChain tools; see **Tool Categories** for the platform vs utility split
+- **Tool System** (`tools/`) - LangChain tools
 - **UI Layer** (`tabs/`) - Gradio modular tabs with real-time updates
 - **Session Management** (`session_manager.py`) - User isolation and cleanup
 - **Error Handler** (`error_handler.py`) - Vector similarity error classification

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ graph TD
 
 - **CmwAgent** (`langchain_agent.py`) - Main orchestrator using pure LangChain patterns
 - **LLMManager** (`llm_manager.py`) - Multi-provider management with persistent instances
-- **Tool System** (`tools/`) - 71 tools (47 CMW Platform + 24 utility)
+- **Tool System** (`tools/`) - 71 LangChain tools; see **Tool Categories** for the platform vs utility split
 - **UI Layer** (`tabs/`) - Gradio modular tabs with real-time updates
 - **Session Management** (`session_manager.py`) - User isolation and cleanup
 - **Error Handler** (`error_handler.py`) - Vector similarity error classification

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The agent supports multiple LLM providers with manual selection:
 
 ### Prerequisites
 
-- Python 3.11+ (local tooling targets 3.11; Hugging Face Spaces metadata uses 3.12)
+- Python 3.12+
 - CMW Platform access credentials
 - At least one LLM provider API key
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The Comindware Analyst Copilot is a LangChain-native AI agent designed for creat
 - **Real-Time Streaming**: Live response streaming with tool usage visualization
 - **Session Isolation**: Each user gets isolated agent instances with proper cleanup
 - **Internationalization**: Full support for English and Russian UI
-- **Comprehensive Tool Suite**: 61 specialized tools (38 CMW Platform + 23 general utility)
+- **Comprehensive Tool Suite**: 71 specialized tools (47 CMW Platform + 24 general utility)
 
 ### Target Use Cases
 
@@ -65,9 +65,9 @@ graph TD
         B4["ErrorHandler<br/>Recovery"]
     end
     
-    subgraph "Tools (61)"
-        C1["CMW Platform<br/>38 tools"]
-        C2["Utility Tools<br/>23 tools"]
+    subgraph "Tools (71)"
+        C1["CMW Platform<br/>47 tools"]
+        C2["Utility Tools<br/>24 tools"]
     end
     
     subgraph "APIs"
@@ -89,7 +89,7 @@ graph TD
 
 - **CmwAgent** (`langchain_agent.py`) - Main orchestrator using pure LangChain patterns
 - **LLMManager** (`llm_manager.py`) - Multi-provider management with persistent instances
-- **Tool System** (`tools/`) - 61 tools (38 CMW Platform + 23 utility)
+- **Tool System** (`tools/`) - 71 tools (47 CMW Platform + 24 utility)
 - **UI Layer** (`tabs/`) - Gradio modular tabs with real-time updates
 - **Session Management** (`session_manager.py`) - User isolation and cleanup
 - **Error Handler** (`error_handler.py`) - Vector similarity error classification
@@ -110,13 +110,13 @@ The agent provides comprehensive integration with the CMW Platform through speci
 
 ### Tool Categories
 
-**CMW Platform Tools (38 tools)**
+**CMW Platform Tools (47 tools)**
 
-- **Applications & Templates (6 tools)**: List/create applications, manage templates, generate URLs, process diagrams
-- **Attributes (15 tools)**: 12 attribute types (Text, Boolean, DateTime, Decimal, Document, Drawing, Duration, Image, Record, Role, Account, Enum) + general operations (get, create, edit, delete, archive)
-- **Templates, forms, toolbars, buttons, records (17 tools)**: Template and record CRUD, form management, toolbars, buttons
+- **Applications & Templates**: List/create applications, manage templates, ontology/schema helpers, entity URLs, import/export
+- **Attributes**: All supported attribute types (Text, Boolean, DateTime, Decimal, Document, Drawing, Duration, Image, Record, Role, Account, Enum) plus get, create, edit, delete, archive
+- **Templates, forms, toolbars, buttons, records**: Template and record CRUD, datasets, forms, toolbars, buttons, record files
 
-**Utility Tools (23 tools)**
+**Utility Tools (24 tools)**
 
 - **Search & Research**: Web search, Wikipedia, ArXiv, deep research
 - **Code Execution**: Multi-language support (Python, Bash, SQL, C, Java)
@@ -155,7 +155,7 @@ The agent supports multiple LLM providers with manual selection:
 
 ### Prerequisites
 
-- Python 3.11+
+- Python 3.11+ (local tooling targets 3.11; Hugging Face Spaces metadata uses 3.12)
 - CMW Platform access credentials
 - At least one LLM provider API key
 
@@ -376,7 +376,7 @@ This is an experimental research project. Contributions are welcome in the form 
 
    WSL (separate venv so Windows and WSL can run in parallel):
    ```bash
-   python3 -m venv .venv-wsl
+   python3 -m venv .venv-wsl   # or .venv-ubuntu
    source .venv-wsl/bin/activate
    ```
 
@@ -427,5 +427,5 @@ This is an experimental research project. Contributions are welcome in the form 
 ### External Services
 
 - **LLM providers**: At least one API key is needed for chat functionality (`OPENROUTER_API_KEY`, `GEMINI_KEY`, `GROQ_API_KEY`, `MISTRAL_API_KEY`, `GIGACHAT_API_KEY`, or `HUGGINGFACE_API_KEY`). See `.env.example` for all options.
-- **CMW Platform** (optional): 38 platform tools require `CMW_BASE_URL`, `CMW_LOGIN`, `CMW_PASSWORD`. The 23 utility tools work without it.
+- **CMW Platform** (optional): 47 platform tools require `CMW_BASE_URL`, `CMW_LOGIN`, `CMW_PASSWORD`. The 24 utility tools work without it.
 - **No Docker, databases, or message queues** are required. The app is a single Python process.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # Based on LangChain and Gradio best practices
 
 # Target Python version
-target-version = "py311"
+target-version = "py312"
 
 # Line length (PEP 8 standard)
 line-length = 88


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `README.md` and repo metadata so documented Python and tool counts match the codebase.

## Changes

- **Python:** Require **3.12+** in README prerequisites; Ruff `target-version` **py312**; **AGENTS.md** header and Ruff line refer to **3.12+**.
- **Tools:** Total **71** in overview and architecture diagram (with split in mermaid only). Tool Categories and External Services avoid repeating per-category counts.
- WSL: mention **`.venv-ubuntu`** as an alternative to **`.venv-wsl`** (consistent with `AGENTS.md`).

## Verification

- Documentation and config edits (`README.md`, `AGENTS.md`, `pyproject.toml`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43acf797-c25c-4344-84a3-eae57bd824cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43acf797-c25c-4344-84a3-eae57bd824cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

